### PR TITLE
nicklathe/clever api v3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Unofficial OmniAuth strategy for [Clever SSO OAuth2](https://dev.clever.com/sso)
 
 Add the gem to your application's Gemfile:
 
-    gem 'omniauth-clever', '~> 2.0.0'
+    gem 'omniauth-clever', '~> 2.0.1'
 
 And then execute:
 

--- a/lib/omniauth/clever/version.rb
+++ b/lib/omniauth/clever/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Clever
-    VERSION = '2.0.0'.freeze
+    VERSION = '2.0.1'.freeze
   end
 end

--- a/omniauth-clever.gemspec
+++ b/omniauth-clever.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.1', '<= 1.5'
+  gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.1', '<= 1.8'
 end


### PR DESCRIPTION
This PR bumps the Clever API version from `2.1` to `3.0`. It also includes an unmerged `omniauth-oauth2` version bump that Artem worked on. I believe this should also be merged to master.

We can either a) merge this and cut a new release off master after or 2) we can merge Artem's `omniauth-oauth2-v1.8` branch to master and I can rebase before merging.